### PR TITLE
Feat: adding return value from the tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ A simple usage of this is:
 ```cpp
 #include "async_pool/task_executer.h"
 #inclde "someother_task_based_code.h"
-#include <chrono>
 #include <iostream>
+#include <chono>
 
 auto my_work(int a, int b, double d) -> void {
     if (b < a) {
@@ -43,4 +43,44 @@ auto main(int, char**) -> int {
 Note that we need to run one of the function: sleep_for, sleep_until or suspend_exec otherwise the tasks will not be switched over, this to simulate async execution.
 If the code is not I/O bound, there is no much use of this pattern as we are not really switching between tasks, and a regular thread pool that run every function to its completion will be more suitable.
 Also note that right now this code do not support return value from a task, nor it is able to accept a function that is accepting any arguments. This limitation from the API can overcome with calling a lambda function.
-You can also use other means such as std::function or std::bind. Please note that since the parameter are passed to some other execution context you must not pass them by reference. In C++ there is no direct way to check this, (something like Rust's [call by value receiver](https://doc.rust-lang.org/std/ops/trait.FnOnce.html)). Later versions will support the return type as well as processing multiple arguments functions.
+You can also use other means such as std::function or std::bind. Please note that since the parameter are passed to some other execution context you must not pass them by reference. 
+In C++ there is no direct way to check this, (something like Rust's [call by value receiver](https://doc.rust-lang.org/std/ops/trait.FnOnce.html)).
+### Return from executer
+This task executor support return value from its context.
+Note that this is a lazy return value, since we are running a task and not a normal function.
+To extract the result from the function, you would need to call:
+```
+result.get()
+```
+on the result from the executer.
+Please note that by calling this, you would be blocked, so do so once you are ready to be blocked.
+```cpp
+#include "async_pool/task_executer.h"
+#include <iostream>
+#include <vector>
+
+auto my_task(int a, int b, int c) -> int {
+    while (a + b < c) {
+        a++;
+        b++;
+        async::sleep_for(1s);
+    }
+    return c * a + b;
+}
+
+auto main(int, char**) -> int {
+    async::task_executer pool{tc};
+    std::vector<async::future_type<std::uint64_t>> counters;
+    for (auto i = 5; i < 50; i++) {
+        counters.push_back(std::move(pool.post([a = i, b = i + 4, c = i * 5]() {
+            return my_task(a, b, c);
+        })));
+    }
+    auto total_count = std::accumulate(std::begin(counters), std::end(counters), 0, [](auto&& count, auto&& f) {
+        return count + f.get();
+    });
+    std::cout << "We accumulated " << total_count << " of results from all the tasks\n";
+    pool.stop();
+}
+
+```

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,3 +13,14 @@ list(APPEND EXTRA_INCLUDES ../ ./ )
 
 target_include_directories(test_pool PUBLIC ${EXTRA_INCLUDES} )
 target_link_libraries(test_pool PUBLIC ${EXTRA_LIBS})
+
+
+list(APPEND MAIN_FILES_WITH_RESULTS
+    test_with_results.cpp
+)
+
+add_executable(test_with_result  ${MAIN_FILES_WITH_RESULTS})
+list(APPEND EXTRA_INCLUDES ../ ./ )
+
+target_include_directories(test_with_result PUBLIC ${EXTRA_INCLUDES} )
+target_link_libraries(test_with_result PUBLIC ${EXTRA_LIBS})

--- a/tests/test_with_results.cpp
+++ b/tests/test_with_results.cpp
@@ -1,0 +1,90 @@
+#include "async_pool/task_executer.h"
+#include "async_pool/pool_utils.h"
+#include <iostream>
+#include <fstream>
+#include <optional>
+#include <sstream>
+#include <string_view>
+#include <iterator>
+
+auto get_rand_letter() -> char {
+    static constexpr std::string_view letters = "abcdefghijklmnopqrspuvwzyz";
+    return letters[rand() % (letters.size() - 1)];
+}
+
+auto just_because(int me, std::string_view fn) -> std::uint64_t {
+    auto my_thread = std::this_thread::get_id();
+    auto end = std::istream_iterator<char>();
+    auto print_details = [me, my_thread](const char* msg) -> void {
+	    std::ostringstream buffer;
+        buffer << "fiber " << me << msg << my_thread << '\n';
+        std::cout << buffer.str() << std::flush;
+        (void)msg;
+    };
+
+    auto find_in_file = [&end](char what, std::istream_iterator<char> curr) -> std::istream_iterator<char> {
+        auto i = std::find_if(curr, end, [what](auto v) {
+            return v == what;
+        });
+        return i == end ? end : ++i;
+    };
+
+    print_details(" started on thread ");
+    std::uint64_t total_count{0};
+    try {
+        std::ifstream input{fn.data()};
+        if (!input) {
+            throw std::runtime_error{"failed to open input file for reading"};
+        }
+
+        auto i = find_in_file(get_rand_letter(), std::istream_iterator<char>(input));
+        
+        while (i != end) {
+            ++total_count;
+            async::sleep_for(std::chrono::milliseconds(1));
+            //async::suspend_exec();
+            auto new_thread = std::this_thread::get_id();
+            if (new_thread != my_thread) {
+                my_thread = new_thread;
+                print_details(" switched to thread ");
+            }
+            i = find_in_file(get_rand_letter(), i);
+        }
+    } catch ( ... ) {
+        print_details( " we have some error! ");
+    }
+    print_details(" is done ");
+    return total_count;
+}
+
+auto main(int argc , char** argv) -> int {
+    if (argc < 2) {
+        std::cerr << "usage: " << argv[0] << ": <file path> [iterations]\n";
+        return -1;
+    }
+
+    auto max = (argc > 2) ? std::atoi(argv[2]) : 1'000;
+    const auto tc = 40u;
+
+    std::cout << "generating " << max << " subtasks for this" << std::endl;
+    auto generate = [max]() mutable  -> std::optional<int> {
+	    if (max > 0) {
+		    return --max;
+	    }
+    	return {};
+    };
+
+    std::cout << "main thread started " << std::this_thread::get_id() << std::endl;
+    async::task_executer pool{tc};
+    std::vector<boost::fibers::future<std::uint64_t>> counters;
+    for (auto g = generate(); g.has_value(); g = generate()) {
+        counters.push_back(std::move(pool.post([val = *g, fn = argv[1]]() {
+            return just_because(val, fn);
+        })));
+    }
+    auto total_count = std::accumulate(std::begin(counters), std::end(counters), 0, [](auto&& count, auto&& f) {
+        return count + f.get();
+    });
+    pool.stop();
+    std::cout << "we are done with all of it, we had " << total_count << " found successful in the file " << argv[1] <<std::endl;
+}


### PR DESCRIPTION
This will enable the use of a return value from a task.
note that this return value is a future, meaning that it would not block the caller. Only when the caller tries to read the return value, it would be blocked.